### PR TITLE
Fix typo in variable name

### DIFF
--- a/ido-ubiquitous.el
+++ b/ido-ubiquitous.el
@@ -527,7 +527,7 @@ completion for them."
             (setq collection (all-completions "" collection predicate)
                   ;; Don't need this any more
                   predicate nil)))
-         (colection-ok
+         (collection-ok
           ;; Don't use ido if the collection is empty or too large.
           (and collection-ok
                collection


### PR DESCRIPTION
I presume, this wasn't intentional, was it?
