### PR TITLE
Use ‘condition-case-unless-debug’ to suppress errors.

### DIFF
--- a/ido-completing-read+.el
+++ b/ido-completing-read+.el
@@ -880,7 +880,7 @@ This has no effect unless `ido-cr+-dynamic-collection' is non-nil."
   (when (and (ido-cr+-active)
              ido-cr+-dynamic-collection)
     (let ((orig-ido-cur-list ido-cur-list))
-      (condition-case err
+      (condition-case-unless-debug err
           (let* ((ido-text
                   (buffer-substring-no-properties (minibuffer-prompt-end)
                                                   ido-eoinput))


### PR DESCRIPTION
With ‘condition-case-unless-debug’ users can still debug errors during dynamic
expansion by setting ‘debug-on-error’ to t.