### PR TITLE
Fix for issue #161 (Sly function crash)

### DIFF
--- a/ido-completing-read+.el
+++ b/ido-completing-read+.el
@@ -300,6 +300,8 @@ disable fallback based on collection size, set this to nil."
     ;; https://github.com/DarwinAwardWinner/ido-completing-read-plus/issues/159
     ffap-read-file-or-url
     ffap-read-file-or-url-internal
+    ;; https://github.com/DarwinAwardWinner/ido-completing-read-plus/issues/161
+    sly-read-symbol-name
     )
   "Functions & commands for which ido-cr+ should be disabled.
 


### PR DESCRIPTION
Added the Sly incompatible function (*sly-read-symbol-name*) to the blacklist.